### PR TITLE
ObservableRecyclerView: set mPrevScrolledChildrenHeight to 0 when scrolled to top.

### DIFF
--- a/library/src/main/java/com/github/ksoichiro/android/observablescrollview/ObservableRecyclerView.java
+++ b/library/src/main/java/com/github/ksoichiro/android/observablescrollview/ObservableRecyclerView.java
@@ -142,6 +142,7 @@ public class ObservableRecyclerView extends RecyclerView implements Scrollable {
                         mPrevFirstVisibleChildHeight = firstVisibleChild.getHeight();
                     } else if (firstVisiblePosition == 0) {
                         mPrevFirstVisibleChildHeight = firstVisibleChild.getHeight();
+                        mPrevScrolledChildrenHeight = 0;
                     }
                     if (mPrevFirstVisibleChildHeight < 0) {
                         mPrevFirstVisibleChildHeight = 0;


### PR DESCRIPTION
This should fix the issue that mScrollY becomes a negative value after fast scrolled down and up to top.

The issue could be produced in SlidingUpRecyclerViewActivity. 
This video may demonstrate it.
https://www.youtube.com/watch?v=fIvh6f22Hzs