### PR TITLE
fix ObservableListView & ObservableGridView get the wrong scrollY when restored

### DIFF
--- a/library/src/main/java/com/github/ksoichiro/android/observablescrollview/ObservableGridView.java
+++ b/library/src/main/java/com/github/ksoichiro/android/observablescrollview/ObservableGridView.java
@@ -443,6 +443,7 @@ public class ObservableGridView extends GridView implements Scrollable {
                         mPrevFirstVisibleChildHeight = firstVisibleChild.getHeight();
                     } else if (firstVisiblePosition == 0) {
                         mPrevFirstVisibleChildHeight = firstVisibleChild.getHeight();
+                        mPrevScrolledChildrenHeight = 0;
                     }
                     if (mPrevFirstVisibleChildHeight < 0) {
                         mPrevFirstVisibleChildHeight = 0;

--- a/library/src/main/java/com/github/ksoichiro/android/observablescrollview/ObservableListView.java
+++ b/library/src/main/java/com/github/ksoichiro/android/observablescrollview/ObservableListView.java
@@ -317,6 +317,7 @@ public class ObservableListView extends ListView implements Scrollable {
                         mPrevFirstVisibleChildHeight = firstVisibleChild.getHeight();
                     } else if (firstVisiblePosition == 0) {
                         mPrevFirstVisibleChildHeight = firstVisibleChild.getHeight();
+                        mPrevScrolledChildrenHeight = 0;
                     }
                     if (mPrevFirstVisibleChildHeight < 0) {
                         mPrevFirstVisibleChildHeight = 0;


### PR DESCRIPTION
Hi I'm using this library to implement my own ViewPagerTabActivity, but when I swipe and first Fragment item in FragmentAdapter got destroyed, it can't restore the right scrollY of ObservableListView because of a negative value on mPrevScrolledChildrenHeight. So I commit this change and at the same time I find that ObservableRecyclerView also has the same fix.

fix ObservableListView & ObservableGridView not restore the right scrollY state, reference: ObservableRecyclerView

Please review and accept it. Appreciated for that.
