### PR TITLE
fix negative scrollY when ObservableView has paddingTop

### DIFF
--- a/library/src/main/java/com/github/ksoichiro/android/observablescrollview/ObservableGridView.java
+++ b/library/src/main/java/com/github/ksoichiro/android/observablescrollview/ObservableGridView.java
@@ -308,7 +308,7 @@ public class ObservableGridView extends GridView implements Scrollable {
 
     @Override
     public int getCurrentScrollY() {
-        return mScrollY;
+        return mScrollY + getPaddingTop();
     }
 
     @Override

--- a/library/src/main/java/com/github/ksoichiro/android/observablescrollview/ObservableListView.java
+++ b/library/src/main/java/com/github/ksoichiro/android/observablescrollview/ObservableListView.java
@@ -261,7 +261,7 @@ public class ObservableListView extends ListView implements Scrollable {
 
     @Override
     public int getCurrentScrollY() {
-        return mScrollY;
+        return mScrollY + getPaddingTop();
     }
 
     private void init() {

--- a/library/src/main/java/com/github/ksoichiro/android/observablescrollview/ObservableRecyclerView.java
+++ b/library/src/main/java/com/github/ksoichiro/android/observablescrollview/ObservableRecyclerView.java
@@ -339,7 +339,7 @@ public class ObservableRecyclerView extends RecyclerView implements Scrollable {
 
     @Override
     public int getCurrentScrollY() {
-        return mScrollY;
+        return mScrollY + getPaddingTop();
     }
 
     @SuppressWarnings("deprecation")


### PR DESCRIPTION
I found that when I add paddingTop to ObservableListView or other Observable View, then I get scrollY will get a negative offset of paddingTop value in pixels.

So I create this PR,  only test it on ListView implement, but I believe that there'll be the same issue with ObservableGridView and ObservableRecyclerView.

Please review that~ Thanks.