### PR TITLE
fix scrollY when the GridView has vertical spacing

### DIFF
--- a/library/src/main/java/com/github/ksoichiro/android/observablescrollview/ObservableGridView.java
+++ b/library/src/main/java/com/github/ksoichiro/android/observablescrollview/ObservableGridView.java
@@ -386,6 +386,14 @@ public class ObservableGridView extends GridView implements Scrollable {
         }
     }
 
+    @Override public int getVerticalSpacing() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
+            return super.getVerticalSpacing();
+        }
+        // getVerticalSpacing was added in 16. We could use reflection to get the value on pre-JB, but that would be expensive.
+        return 0;
+    }
+
     private void init() {
         mChildrenHeights = new SparseIntArray();
         mHeaderViewInfos = new ArrayList<>();
@@ -435,7 +443,7 @@ public class ObservableGridView extends GridView implements Scrollable {
                             }
                         }
                     }
-                    mPrevScrolledChildrenHeight += mPrevFirstVisibleChildHeight + skippedChildrenHeight;
+                    mPrevScrolledChildrenHeight += mPrevFirstVisibleChildHeight + skippedChildrenHeight + getVerticalSpacing();
                     mPrevFirstVisibleChildHeight = firstVisibleChild.getHeight();
                 } else if (firstVisiblePosition < mPrevFirstVisiblePosition) {
                     // scroll up
@@ -447,7 +455,7 @@ public class ObservableGridView extends GridView implements Scrollable {
                             }
                         }
                     }
-                    mPrevScrolledChildrenHeight -= firstVisibleChild.getHeight() + skippedChildrenHeight;
+                    mPrevScrolledChildrenHeight -= firstVisibleChild.getHeight() + skippedChildrenHeight + getVerticalSpacing();
                     mPrevFirstVisibleChildHeight = firstVisibleChild.getHeight();
                 } else if (firstVisiblePosition == 0) {
                     mPrevFirstVisibleChildHeight = firstVisibleChild.getHeight();


### PR DESCRIPTION
The scrollY is off when items have vertical spacing. This fixes the scrollY jumping to incorrect values while scrolling. 

This will still be an issue on pre-JB. If you did want to fix this problem for API 11-16, you could use reflection to get the vertical spacing. Example:

``` java

private Integer mVerticalSpacing;

@Override public int getVerticalSpacing() {
  if (VERSION.SDK_INT >= VERSION_CODES.JELLY_BEAN) {
    return super.getVerticalSpacing();
  }
  if (mVerticalSpacing == null) {
    try {
      Field field = GridView.class.getDeclaredField("mVerticalSpacing");
      if (!field.isAccessible()) {
        field.setAccessible(true);
      }
      mVerticalSpacing = field.getInt(this);
    } catch (Exception e) {
      mVerticalSpacing = 0;
    }
  }
  return mVerticalSpacing;
}
```
