### PR TITLE
check type of state in ObservableRecyclerView#onRestoreInstanceState(Parcelable)

### DIFF
--- a/library/src/main/java/com/github/ksoichiro/android/observablescrollview/ObservableRecyclerView.java
+++ b/library/src/main/java/com/github/ksoichiro/android/observablescrollview/ObservableRecyclerView.java
@@ -74,6 +74,10 @@ public class ObservableRecyclerView extends RecyclerView implements Scrollable {
 
     @Override
     public void onRestoreInstanceState(Parcelable state) {
+        if (!(state instanceof SavedState)) {
+            super.onRestoreInstanceState(state);
+            return;
+        }
         SavedState ss = (SavedState) state;
         mPrevFirstVisiblePosition = ss.prevFirstVisiblePosition;
         mPrevFirstVisibleChildHeight = ss.prevFirstVisibleChildHeight;


### PR DESCRIPTION
fix #254 

I'm not 100% sure if this is a right way, but recent version of support RecyclerView is doing this check, so I think it is reasonable to do same in this library
